### PR TITLE
Remove version number from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
     "name": "broadcastt/broadcastt-php-http",
-    "version": "0.3.0",
     "homepage": "https://broadcastt.xyz/",
     "description": "PHP library for Broadcastt HTTP API",
     "keywords": ["broadcastt", "broadcast", "events", "messaging", "publish", "push", "rest", "realtime", "real-time", "real time", "trigger"],


### PR DESCRIPTION
Composer yields the following message:
> The version field is present, it is recommended to leave it out if the package is published on Packagist.