### PR TITLE
Let exceptions to bubble

### DIFF
--- a/src/BroadcasttClient.php
+++ b/src/BroadcasttClient.php
@@ -365,7 +365,7 @@ class BroadcasttClient implements LoggerAwareInterface
 
             // json_encode returns false on failure
             if ($data === false) {
-                throw new JsonEncodeException('Failed to perform json_encode on the the provided data', $data);
+                throw new JsonEncodeException($data, json_last_error_msg(), json_last_error());
             }
         }
 
@@ -408,7 +408,7 @@ class BroadcasttClient implements LoggerAwareInterface
 
                 // json_encode returns false on failure
                 if ($data === false) {
-                    throw new JsonEncodeException('Failed to perform json_encode on the the provided data', $data);
+                    throw new JsonEncodeException($data, json_last_error_msg(), json_last_error());
                 }
 
                 $batch[$key]['data'] = $data;

--- a/src/BroadcasttClient.php
+++ b/src/BroadcasttClient.php
@@ -360,18 +360,19 @@ class BroadcasttClient implements LoggerAwareInterface
         $this->validateChannels($channels);
         $this->validateSocketId($socketId);
 
+        $jsonData = $data;
         if (!$jsonEncoded) {
-            $data = json_encode($data);
+            $jsonData = json_encode($data);
 
             // json_encode returns false on failure
-            if ($data === false) {
+            if ($jsonData === false) {
                 throw new JsonEncodeException($data, json_last_error_msg(), json_last_error());
             }
         }
 
         $postParams = [];
         $postParams['name'] = $name;
-        $postParams['data'] = $data;
+        $postParams['data'] = $jsonData;
         $postParams['channels'] = $channels;
 
         if ($socketId !== null) {
@@ -404,14 +405,14 @@ class BroadcasttClient implements LoggerAwareInterface
             }
 
             if (!$jsonEncoded) {
-                $data = json_encode($event['data']);
+                $jsonData = json_encode($event['data']);
 
                 // json_encode returns false on failure
-                if ($data === false) {
-                    throw new JsonEncodeException($data, json_last_error_msg(), json_last_error());
+                if ($jsonData === false) {
+                    throw new JsonEncodeException($event['data'], json_last_error_msg(), json_last_error());
                 }
 
-                $batch[$key]['data'] = $data;
+                $batch[$key]['data'] = $jsonData;
             }
         }
 

--- a/src/Exception/JsonEncodeException.php
+++ b/src/Exception/JsonEncodeException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Broadcastt\Exception;
+
+class JsonEncodeException extends \RuntimeException
+{
+    private $data;
+
+    public function __construct($message, $data, $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->data = $data;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+}

--- a/src/Exception/JsonEncodeException.php
+++ b/src/Exception/JsonEncodeException.php
@@ -6,7 +6,7 @@ class JsonEncodeException extends \RuntimeException
 {
     private $data;
 
-    public function __construct($message, $data, $code = 0, \Throwable $previous = null)
+    public function __construct($data, $message, $code, \Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->data = $data;

--- a/tests/Feature/BroadcasttTriggerBatchTest.php
+++ b/tests/Feature/BroadcasttTriggerBatchTest.php
@@ -243,6 +243,11 @@ class BroadcasttTriggerBatchTest extends TestCase
         $batch = [];
         $batch[] = ['channel' => 'test-channel', 'name' => 'test-event', 'data' => $data];
         $this->expectException(JsonEncodeException::class);
-        $this->client->triggerBatch($batch);
+        try {
+            $this->client->triggerBatch($batch);
+        } catch (JsonEncodeException $e) {
+            $this->assertEquals($e->getData(), $data);
+            throw $e;
+        }
     }
 }

--- a/tests/Feature/BroadcasttTriggerBatchTest.php
+++ b/tests/Feature/BroadcasttTriggerBatchTest.php
@@ -7,6 +7,7 @@ use Broadcastt\Exception\InvalidChannelNameException;
 use Broadcastt\Exception\InvalidDataException;
 use Broadcastt\Exception\InvalidHostException;
 use Broadcastt\Exception\InvalidSocketIdException;
+use Broadcastt\Exception\JsonEncodeException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Handler\MockHandler;
@@ -234,4 +235,14 @@ class BroadcasttTriggerBatchTest extends TestCase
         $this->assertFalse($response);
     }
 
+    public function testCanTriggerBatchThrowExceptionOnJsonEncodeFailure()
+    {
+        // data from https://www.php.net/manual/en/function.json-last-error.php
+        $data = "\xB1\x31";
+
+        $batch = [];
+        $batch[] = ['channel' => 'test-channel', 'name' => 'test-event', 'data' => $data];
+        $this->expectException(JsonEncodeException::class);
+        $this->client->triggerBatch($batch);
+    }
 }

--- a/tests/Feature/BroadcasttTriggerBatchTest.php
+++ b/tests/Feature/BroadcasttTriggerBatchTest.php
@@ -8,6 +8,7 @@ use Broadcastt\Exception\InvalidDataException;
 use Broadcastt\Exception\InvalidHostException;
 use Broadcastt\Exception\InvalidSocketIdException;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -202,8 +203,8 @@ class BroadcasttTriggerBatchTest extends TestCase
         $batch = [];
         $batch[] = ['channel' => 'test-channel', 'name' => 'test-event', 'data' => ['test-key' => 'test-val']];
         $batch[] = ['channel' => 'test-channel2', 'name' => 'test-event2', 'data' => ['test-key' => 'test-val2']];
-        $response = $this->client->triggerBatch($batch);
-        $this->assertFalse($response);
+        $this->expectException(GuzzleException::class);
+        $this->client->triggerBatch($batch);
     }
 
     public function testCanTriggerBatchHandlePayloadTooLargeResponseWhenGuzzleExceptionsAreDisabled()

--- a/tests/Feature/BroadcasttTriggerBatchTest.php
+++ b/tests/Feature/BroadcasttTriggerBatchTest.php
@@ -182,7 +182,7 @@ class BroadcasttTriggerBatchTest extends TestCase
         $this->client->triggerBatch($batch);
     }
 
-    public function testCanTriggerBatchHandlePayloadTooLargeResponse()
+    public function testCanTriggerBatchThrowExceptionOnPayloadTooLargeResponse()
     {
         $mockHandler = new MockHandler([
             new Response(413, [], '{}'),

--- a/tests/Feature/BroadcasttTriggerTest.php
+++ b/tests/Feature/BroadcasttTriggerTest.php
@@ -7,6 +7,7 @@ use Broadcastt\Exception\InvalidSocketIdException;
 use Broadcastt\Exception\TooManyChannelsException;
 use Broadcastt\Exception\InvalidHostException;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
@@ -165,7 +166,6 @@ class BroadcasttTriggerTest extends TestCase
         $this->client->setGuzzleClient($guzzleClient);
 
         $this->expectException(InvalidArgumentException::class);
-
         $this->client->trigger($invalidChannel, 'test-event', '');
     }
 
@@ -181,12 +181,11 @@ class BroadcasttTriggerTest extends TestCase
 
         $this->client->setGuzzleClient($guzzleClient);
 
-        $this->expectException(TooManyChannelsException::class);
-
         $channels = [];
         for ($i = 0; $i < 101; $i++) {
             $channels[] = 'test-channel' . $i;
         }
+        $this->expectException(TooManyChannelsException::class);
         $this->client->trigger($channels, 'test-event', '');
     }
 
@@ -207,7 +206,6 @@ class BroadcasttTriggerTest extends TestCase
         $this->client->setGuzzleClient($guzzleClient);
 
         $this->expectException(InvalidSocketIdException::class);
-
         $this->client->trigger('test-channel', 'test-event', '', $invalidSocketId);
     }
 
@@ -225,7 +223,6 @@ class BroadcasttTriggerTest extends TestCase
         $this->client->host = 'http://test.xyz';
 
         $this->expectException(InvalidHostException::class);
-
         $this->client->trigger('test-channel', 'test-event', '');
     }
 
@@ -248,8 +245,8 @@ class BroadcasttTriggerTest extends TestCase
 
         $this->client->setGuzzleClient($guzzleClient);
 
-        $response = $this->client->trigger('test-channel', 'test-event', '');
-        $this->assertFalse($response);
+        $this->expectException(GuzzleException::class);
+        $this->client->trigger('test-channel', 'test-event', '');
     }
 
     public function testCanTriggerHandlePayloadTooLargeResponseWhenGuzzleExceptionsAreDisabled()

--- a/tests/Feature/BroadcasttTriggerTest.php
+++ b/tests/Feature/BroadcasttTriggerTest.php
@@ -280,6 +280,11 @@ class BroadcasttTriggerTest extends TestCase
         $data = "\xB1\x31";
 
         $this->expectException(JsonEncodeException::class);
-        $this->client->trigger('test-channel', 'test-event', $data);
+        try {
+            $this->client->trigger('test-channel', 'test-event', $data);
+        } catch (JsonEncodeException $e) {
+            $this->assertEquals($e->getData(), $data);
+            throw $e;
+        }
     }
 }

--- a/tests/Feature/BroadcasttTriggerTest.php
+++ b/tests/Feature/BroadcasttTriggerTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use Broadcastt\BroadcasttClient;
 use Broadcastt\Exception\InvalidSocketIdException;
+use Broadcastt\Exception\JsonEncodeException;
 use Broadcastt\Exception\TooManyChannelsException;
 use Broadcastt\Exception\InvalidHostException;
 use GuzzleHttp\Client;
@@ -273,4 +274,12 @@ class BroadcasttTriggerTest extends TestCase
         $this->assertFalse($response);
     }
 
+    public function testCanTriggerThrowExceptionOnJsonEncodeFailure()
+    {
+        // data from https://www.php.net/manual/en/function.json-last-error.php
+        $data = "\xB1\x31";
+
+        $this->expectException(JsonEncodeException::class);
+        $this->client->trigger('test-channel', 'test-event', $data);
+    }
 }

--- a/tests/Feature/BroadcasttTriggerTest.php
+++ b/tests/Feature/BroadcasttTriggerTest.php
@@ -227,7 +227,7 @@ class BroadcasttTriggerTest extends TestCase
         $this->client->trigger('test-channel', 'test-event', '');
     }
 
-    public function testCanTriggerHandlePayloadTooLargeResponse()
+    public function testCanTriggerThrowExceptionOnPayloadTooLargeResponse()
     {
         $mockHandler = new MockHandler([
             new Response(413, [], '{}'),


### PR DESCRIPTION
This PR allows exceptions (mainly `GuzzleException`) to bubble up to the caller of the client instance. Previous implementation swallowed it which made it hard to debug.